### PR TITLE
Update URLs to point to the dask-image template

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -13,7 +13,7 @@ Types of Contributions
 Report Bugs
 ~~~~~~~~~~~
 
-Report bugs at https://github.com/nanshe-org/nanshe-cookiecutter/issues
+Report bugs at https://github.com/dask-image/dask-image-cookiecutter/issues
 
 If you are reporting a bug, please include:
 
@@ -42,7 +42,7 @@ official docs, in docstrings, or even on the web in blog posts, articles, and su
 Submit Feedback
 ~~~~~~~~~~~~~~~
 
-The best way to send feedback is to file an issue at https://github.com/nanshe-org/nanshe-cookiecutter/issues.
+The best way to send feedback is to file an issue at https://github.com/dask-image/dask-image-cookiecutter/issues.
 
 If you are proposing a new feature:
 
@@ -136,7 +136,7 @@ Before you submit a pull request, check that it meets these guidelines:
    feature to the list in README.rst.
 
 3. The pull request should work for Python 2.7, 3.4 and 3.5, and for PyPy. Check
-   https://travis-ci.org/nanshe-org/nanshe-cookiecutter/pull_requests
+   https://travis-ci.org/dask-image/dask-image-cookiecutter/pull_requests
    and make sure that the tests pass for all supported Python versions.
 
 Add a New Test
@@ -167,6 +167,6 @@ To write and run your new test, follow these steps:
 
 6. Rerun your test and confirm that your test passes. If it passes, congratulations!
 
-.. cookiecutter: https://github.com/nanshe-org/nanshe-cookiecutter
+.. cookiecutter: https://github.com/dask-image/dask-image-cookiecutter
 .. virtualenv: https://virtualenv.pypa.io/en/stable/installation
 .. git: https://git-scm.com/book/en/v2/Getting-Started-Installing-Git

--- a/README.rst
+++ b/README.rst
@@ -2,13 +2,13 @@
 Cookiecutter PyPackage
 ======================
 
-.. image:: https://pyup.io/repos/github/nanshe-org/nanshe-cookiecutter/shield.svg
-     :target: https://pyup.io/repos/github/nanshe-org/nanshe-cookiecutter/
+.. image:: https://pyup.io/repos/github/dask-image/dask-image-cookiecutter/shield.svg
+     :target: https://pyup.io/repos/github/dask-image/dask-image-cookiecutter/
      :alt: Updates
 
 Cookiecutter_ template for a Python package.
 
-* GitHub repo: https://github.com/nanshe-org/nanshe-cookiecutter/
+* GitHub repo: https://github.com/dask-image/dask-image-cookiecutter/
 * Documentation: https://cookiecutter-pypackage.readthedocs.io/
 * Free software: BSD license
 
@@ -30,14 +30,14 @@ Build Status
 
 Linux:
 
-.. image:: https://img.shields.io/travis/nanshe-org/nanshe-cookiecutter.svg
-    :target: https://travis-ci.org/nanshe-org/nanshe-cookiecutter
+.. image:: https://img.shields.io/travis/dask-image/dask-image-cookiecutter.svg
+    :target: https://travis-ci.org/dask-image/dask-image-cookiecutter
     :alt: Linux build status on Travis CI
 
 Windows:
 
-.. image:: https://ci.appveyor.com/api/projects/status/github/nanshe-org/nanshe-cookiecutter?branch=master
-    :target: https://ci.appveyor.com/project/nanshe-org/nanshe-cookiecutter/branch/master
+.. image:: https://ci.appveyor.com/api/projects/status/github/jakirkham/dask-image-cookiecutter?branch=master
+    :target: https://ci.appveyor.com/project/jakirkham/dask-image-cookiecutter/branch/master
     :alt: Windows build status on Appveyor
 
 Quickstart
@@ -50,7 +50,7 @@ Cookiecutter 1.4.0 or higher)::
 
 Generate a Python package project::
 
-    cookiecutter https://github.com/nanshe-org/nanshe-cookiecutter.git
+    cookiecutter https://github.com/dask-image/dask-image-cookiecutter.git
 
 Then:
 
@@ -123,5 +123,5 @@ make my own packaging experience better.
 .. _`tony/cookiecutter-pypackage-pythonic`: https://github.com/tony/cookiecutter-pypackage-pythonic
 .. _`ardydedase/cookiecutter-pypackage`: https://github.com/ardydedase/cookiecutter-pypackage
 .. _github comparison view: https://github.com/tony/cookiecutter-pypackage-pythonic/compare/audreyr:master...master
-.. _`network`: https://github.com/nanshe-org/nanshe-cookiecutter/network
-.. _`family tree`: https://github.com/nanshe-org/nanshe-cookiecutter/network/members
+.. _`network`: https://github.com/dask-image/dask-image-cookiecutter/network
+.. _`family tree`: https://github.com/dask-image/dask-image-cookiecutter/network/members

--- a/docs/troubleshooting.rst
+++ b/docs/troubleshooting.rst
@@ -7,7 +7,7 @@ Troubleshooting
 .. note:: Can you help improve this file? `Edit this file`_
           and submit a pull request with your improvements!
 
-.. _`Edit this file`: https://github.com/nanshe-org/nanshe-cookiecutter/blob/master/docs/troubleshooting.rst
+.. _`Edit this file`: https://github.com/dask-image/dask-image-cookiecutter/blob/master/docs/troubleshooting.rst
 
 
 Windows Issues

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -4,7 +4,7 @@ Tutorial
 .. note:: Did you find any of these instructions confusing? `Edit this file`_
           and submit a pull request with your improvements!
 
-.. _`Edit this file`: https://github.com/nanshe-org/nanshe-cookiecutter/blob/master/docs/tutorial.rst
+.. _`Edit this file`: https://github.com/dask-image/dask-image-cookiecutter/blob/master/docs/tutorial.rst
 
 To start with, you will need a `GitHub account`_ and an account on `PyPI`_. Create these before you get started on this tutorial. If you are new to Git and GitHub, you should probably spend a few minutes on some of the tutorials at the top of the page at `GitHub Help`_.
 
@@ -53,7 +53,7 @@ Use cookiecutter, pointing it at the cookiecutter-pypackage repo:
 
 .. code-block:: bash
 
-    cookiecutter https://github.com/nanshe-org/nanshe-cookiecutter.git
+    cookiecutter https://github.com/dask-image/dask-image-cookiecutter.git
 
 You'll be asked to enter a bunch of values to set the package up.
 If you don't know what to enter, stick with the defaults.
@@ -164,4 +164,4 @@ Having problems?
 
 Visit our :ref:`troubleshooting` page for help. If that doesn't help, go to our `Issues`_ page and create a new Issue. Be sure to give as much information as possible.
 
-.. _`Issues`: https://github.com/nanshe-org/nanshe-cookiecutter/issues
+.. _`Issues`: https://github.com/dask-image/dask-image-cookiecutter/issues

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(
     author='Audrey Roy Greenfeld',
     license='BSD',
     author_email='aroy@alum.mit.edu',
-    url='https://github.com/nanshe-org/nanshe-cookiecutter',
+    url='https://github.com/dask-image/dask-image-cookiecutter',
     keywords=['cookiecutter', 'template', 'package', ],
     classifiers=[
         'Development Status :: 4 - Beta',

--- a/tests/test_bake_project.py
+++ b/tests/test_bake_project.py
@@ -114,7 +114,7 @@ def test_bake_and_run_travis_pypi_setup(cookies):
 
         # when:
         travis_setup_cmd = ('python travis_pypi_setup.py'
-                            ' --repo nanshe-org/nanshe-cookiecutter --password invalidpass')
+                            ' --repo dask-image/dask-image-cookiecutter --password invalidpass')
         run_inside_dir(travis_setup_cmd, project_path)
         # then:
         result_travis_config = yaml.load(result.project.join(".travis.yml").open())
@@ -202,7 +202,7 @@ def test_project_with_invalid_module_name(cookies):
 
     # when:
     travis_setup_cmd = ('python travis_pypi_setup.py'
-                        ' --repo nanshe-org/nanshe-cookiecutter --password invalidpass')
+                        ' --repo dask-image/dask-image-cookiecutter --password invalidpass')
     run_inside_dir(travis_setup_cmd, project_path)
 
     # then:

--- a/{{cookiecutter.project_slug}}/README.rst
+++ b/{{cookiecutter.project_slug}}/README.rst
@@ -45,8 +45,8 @@ Features
 Credits
 ---------
 
-This package was created with Cookiecutter_ and the `nanshe-org/nanshe-cookiecutter`_ project template.
+This package was created with Cookiecutter_ and the `dask-image/dask-image-cookiecutter`_ project template.
 
 .. _Cookiecutter: https://github.com/audreyr/cookiecutter
-.. _`nanshe-org/nanshe-cookiecutter`: https://github.com/nanshe-org/nanshe-cookiecutter
+.. _`dask-image/dask-image-cookiecutter`: https://github.com/dask-image/dask-image-cookiecutter
 


### PR DESCRIPTION
Borrowed from the nanshe-org cookiecutter template and split off.

ref: https://github.com/nanshe-org/nanshe-cookiecutter