### PR TITLE
Export core's contents

### DIFF
--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/__init__.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/__init__.py
@@ -6,3 +6,5 @@ __email__ = "{{ cookiecutter.email }}"
 from ._version import get_versions
 __version__ = get_versions()['version']
 del get_versions
+
+from {{ cookiecutter.project_slug }}.core import *


### PR DESCRIPTION
Make sure to import all contents from `core` into `__init__` so they are visible at the package level.