### PR TITLE
Drop trailing space

### DIFF
--- a/{{cookiecutter.project_name}}/docs/installation.rst
+++ b/{{cookiecutter.project_name}}/docs/installation.rst
@@ -14,7 +14,7 @@ To install {{ cookiecutter.project_name }}, run this command in your terminal:
 
     $ pip install {{ cookiecutter.project_name }}
 
-This is the preferred method to install {{ cookiecutter.project_name }}, as it will always install the most recent stable release. 
+This is the preferred method to install {{ cookiecutter.project_name }}, as it will always install the most recent stable release.
 
 If you don't have `pip`_ installed, this `Python installation guide`_ can guide
 you through the process.


### PR DESCRIPTION
Found a trailing space in the template project's installation docs. As this shouldn't be there, it has been dropped.